### PR TITLE
Removes packit dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,5 @@ go 1.16
 require (
 	github.com/onsi/gomega v1.18.1
 	github.com/paketo-buildpacks/occam v0.7.0
-	github.com/paketo-buildpacks/packit/v2 v2.1.0
 	github.com/sclevine/spec v1.4.0
 )

--- a/integration/init_test.go
+++ b/integration/init_test.go
@@ -1,12 +1,11 @@
 package integration_test
 
 import (
-	"bytes"
+	"os/exec"
 	"path/filepath"
 	"testing"
 	"time"
 
-	"github.com/paketo-buildpacks/packit/v2/pexec"
 	"github.com/sclevine/spec"
 	"github.com/sclevine/spec/report"
 
@@ -18,14 +17,8 @@ var webServersBuildpack string
 func TestIntegration(t *testing.T) {
 	Expect := NewWithT(t).Expect
 
-	bash := pexec.NewExecutable("bash")
-	buffer := bytes.NewBuffer(nil)
-	err := bash.Execute(pexec.Execution{
-		Args:   []string{"-c", "../scripts/package.sh --version 1.2.3"},
-		Stdout: buffer,
-		Stderr: buffer,
-	})
-	Expect(err).NotTo(HaveOccurred(), buffer.String)
+	output, err := exec.Command("bash", "-c", "../scripts/package.sh --version 1.2.3").CombinedOutput()
+	Expect(err).NotTo(HaveOccurred(), string(output))
 
 	webServersBuildpack, err = filepath.Abs("../build/buildpackage.cnb")
 	Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
These are the reasons why I think we should remove `packit` as a dependency:
1. I think that there is no need to import the library if it is doing something that is accomplished just as well by a standard library. The only really great reason I can think to use `pexec` is in an interface context for mocking.
2. It will make the language family buildpacks clearly agnostic of any buildpack library which it should be because no library is required to build these.
3. Makes it so these buildpacks do not need to be upgraded in the same say in the feature.